### PR TITLE
explicit requirements, add teams

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,15 @@ name: 'Your name here'
 description: 'Provide a description here'
 author: 'Your name or organization here'
 inputs:
+  teams:
+    description: 'authorized teams to execute an action'
+    required: false
   token:
     description: 'default actions-bot token'
+    required: true
   admin_token:
     description: 'token with admin access to org'
+    required: true
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
This should address the warning seen on the console output: 

`##[warning]Unexpected input 'teams', valid inputs are ['token', 'admin_token']` seen [here](https://github.com/department-of-veterans-affairs/github-user-requests/runs/751820728?check_suite_focus=true#step:2:24)